### PR TITLE
Add xml file error log delete exception

### DIFF
--- a/src/Elmah/Elmah.csproj
+++ b/src/Elmah/Elmah.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -283,6 +283,7 @@
     <Compile Include="XmlFileErrorLog.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="XmlFileErrorLogDeleteException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Elmah/XmlFileErrorLog.cs
+++ b/src/Elmah/XmlFileErrorLog.cs
@@ -172,6 +172,7 @@ namespace Elmah
         /// <summary>
         /// Deletes Old files according the <code>size</code> parameter
         /// </summary>
+        /// <exception cref="XmlFileErrorLogDeleteException">Thrown when unable to delete files for various reasons.</exception>
         private void DeleteOldFiles()
         {
             if (_fileListSize == 0)
@@ -196,17 +197,17 @@ namespace Elmah
                     }
                 }
             }
-            catch (IOException)
+            catch (IOException ex)
             {
-                throw new Exception(string.Format("{0} The target file is open or memory-mapped or there is an open handle on the file", ErrorLogMessage));
+                throw new XmlFileErrorLogDeleteException(string.Format("{0} The target file is open or memory-mapped or there is an open handle on the file", ErrorLogMessage), ex);
             }
             catch (Exception ex) when (ex is SecurityException || ex is UnauthorizedAccessException)
             {
-                throw new Exception(string.Format("{0} Elmah does not have permission to delete old files.", ErrorLogMessage));
+                throw new XmlFileErrorLogDeleteException(string.Format("{0} Elmah does not have permission to delete old files.", ErrorLogMessage), ex);
             }
             catch (Exception ex)
             {
-                throw new Exception(string.Format("{0} {1}", ErrorLogMessage, ex.Message));
+                throw new XmlFileErrorLogDeleteException(string.Format("{0} {1}", ErrorLogMessage, ex.Message), ex);
             }
         }
 

--- a/src/Elmah/XmlFileErrorLog.cs
+++ b/src/Elmah/XmlFileErrorLog.cs
@@ -176,13 +176,20 @@ namespace Elmah
         }
 
         /// <summary>
-        /// Check if the exception is of type XmlFileErrorLogDeleteException.
+        /// Check if the exception or its InnerException is of type XmlFileErrorLogDeleteException.
+        /// InnerException is checked in in case the XmlFileErrorLogDeleteException is caught and wrapped
+        /// by some other code up the call stack.
         /// </summary>
         /// <param name="ex">Exception to test</param>
-        /// <returns>True if the exception type XmlFileErrorLogDeleteException, otherwise false.</returns>
+        /// <returns>True if the exception or its InnerExcpetion if of type 
+        /// XmlFileErrorLogDeleteException, otherwise false.</returns>
         private bool IsXmlFileErrorLogDeleteException(Exception ex)
         {
-            return ex.GetType() == typeof(XmlFileErrorLogDeleteException);
+            if (ex == null) return false;
+
+            if (ex.GetType() == typeof(XmlFileErrorLogDeleteException)) return true;
+
+            return IsXmlFileErrorLogDeleteException(ex.InnerException);
         }
 
         /// <summary>

--- a/src/Elmah/XmlFileErrorLog.cs
+++ b/src/Elmah/XmlFileErrorLog.cs
@@ -222,15 +222,24 @@ namespace Elmah
             }
             catch (IOException ex)
             {
-                throw new XmlFileErrorLogDeleteException(string.Format("{0} The target file is open or memory-mapped or there is an open handle on the file", ErrorLogMessage), ex);
+                var error = new Error(
+                    new XmlFileErrorLogDeleteException(string.Format("{0} The target file is open or memory-mapped or there is an open handle on the file", ErrorLogMessage), ex)
+                    , new System.Web.HttpContextWrapper(System.Web.HttpContext.Current));
+                Log(error);
             }
             catch (Exception ex) when (ex is SecurityException || ex is UnauthorizedAccessException)
             {
-                throw new XmlFileErrorLogDeleteException(string.Format("{0} Elmah does not have permission to delete old files.", ErrorLogMessage), ex);
+                var error = new Error(
+                    new XmlFileErrorLogDeleteException(string.Format("{0} Elmah does not have permission to delete old files.", ErrorLogMessage), ex)
+                    , new System.Web.HttpContextWrapper(System.Web.HttpContext.Current));
+                Log(error);
             }
             catch (Exception ex)
             {
-                throw new XmlFileErrorLogDeleteException(string.Format("{0} {1}", ErrorLogMessage, ex.Message), ex);
+                var error = new Error(
+                    new XmlFileErrorLogDeleteException(string.Format("{0} {1}", ErrorLogMessage, ex.Message), ex)
+                    , new System.Web.HttpContextWrapper(System.Web.HttpContext.Current));
+                Log(error);
             }
         }
 

--- a/src/Elmah/XmlFileErrorLogDeleteException.cs
+++ b/src/Elmah/XmlFileErrorLogDeleteException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Elmah
+{
+    /// <summary>
+    /// Custom exception specifically designed for deleting old logs. Using this 
+    /// exception type will skip the log delete code, so to prevent loops of 
+    /// trying to delete a log, throwing an exceptions, recording a new log and 
+    /// then throwing another exception...
+    /// </summary>
+    internal class XmlFileErrorLogDeleteException : Exception
+    {
+        public XmlFileErrorLogDeleteException()
+        {
+        }
+
+        public XmlFileErrorLogDeleteException(string message)
+            : base(message)
+        {
+        }
+
+        public XmlFileErrorLogDeleteException(string message, Exception internalException)
+            : base(message, internalException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Hi @marcusvnac 
re https://github.com/elmah/Elmah/pull/405

I looked into the code and any exceptions created via the Log method are ignored. See 
\Elmah.AspNet\ErrorLogModule.cs lines 125-136. So you don't have to worry about a loop, but the exceptions are also not recorded, so you don't know anything is going wrong and the log files will continue to accumulate.

I've got a fix that will record the DeleteOldFiles exceptions, but it involves calling the XmlFileErrorLog's Log method from within the catch blocks instead of throwing the exceptions. The downside of this approach is that is sidesteps Elmah's filtering and maybe other capabilities, and I don't know if atifaziz will accept it.

Let me know what you think.